### PR TITLE
Use timeout from jQuery ajax settings to allow for longer-than-default-60-seconds requests

### DIFF
--- a/src/www/ios/xhr-polyfill.js
+++ b/src/www/ios/xhr-polyfill.js
@@ -602,8 +602,12 @@
 
       var timeoutInSecs = (isNaN(reqContext.timeout) ? undefined : (reqContext.timeout / 1000));
       
-      // change for Lindt: hard timeout!
-      timeoutInSecs = 180;
+      // use timeout from jQuery ajax settings
+      try {
+        if (typeof jQuery != 'undefined' && jQuery.ajaxSettings.timeout > 0) {
+          timeoutInSecs = jQuery.ajaxSettings.timeout;
+        }
+      } catch(e) { }
 
       var reqPayLoad = {id: id, callback: "nativeXHRResponse",
         url: HttpHandler._resolveUri(reqContext.url), method: reqContext.method,

--- a/src/www/ios/xhr-polyfill.js
+++ b/src/www/ios/xhr-polyfill.js
@@ -601,6 +601,9 @@
       reqContext.requestData = undefined;
 
       var timeoutInSecs = (isNaN(reqContext.timeout) ? undefined : (reqContext.timeout / 1000));
+      
+      // change for Lindt: hard timeout!
+      timeoutInSecs = 180;
 
       var reqPayLoad = {id: id, callback: "nativeXHRResponse",
         url: HttpHandler._resolveUri(reqContext.url), method: reqContext.method,


### PR DESCRIPTION
See https://github.com/globules-io/cordova-plugin-ios-xhr/issues/11 for details and background.

Should be a non-invasive change without negative consequences.
Could also consider a plugin-specific configuration object if using jQuery settings brings up side effects.